### PR TITLE
Add support for clearing neighbors of an already clicked cell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 
 /client/node_modules
 /client/build
+/client/coverage
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,32 +1,29 @@
-import './App.css';
+import "./App.css";
 import Board, { CellIndex } from "./engine/Board";
-import GameBoard from "./GameBoard/GameBoard"
-import { useState } from 'react';
+import GameBoard from "./GameBoard/GameBoard";
+import { useState } from "react";
 
 document.addEventListener("contextmenu", (event) => {
-    event.preventDefault();
+  event.preventDefault();
 });
 
 function App() {
   const [gameBoard, setGameBoard] = useState(new Board(20, 20, 50));
 
   let onCellClick = (e: React.MouseEvent<HTMLDivElement>, clickedIndex: CellIndex) => {
-    if (e.type === "click"){
-      const newBoard = gameBoard.click(clickedIndex)
-      setGameBoard(newBoard)
+    if (e.type === "click") {
+      const newBoard = gameBoard.click(clickedIndex);
+      setGameBoard(newBoard);
     } else if (e.type === "contextmenu") {
-      e.preventDefault()
-      const newBoard = gameBoard.rightClick(clickedIndex)
-      setGameBoard(newBoard)
+      const newBoard = gameBoard.rightClick(clickedIndex);
+      setGameBoard(newBoard);
     }
-
-    
-  }
+  };
 
   return (
     <div className="App">
       <header className="App-header">
-        <GameBoard gameBoard={gameBoard} onCellClick={onCellClick}/>
+        <GameBoard gameBoard={gameBoard} onCellClick={onCellClick} />
       </header>
     </div>
   );

--- a/client/src/GameBoard/GameBoard.test.tsx
+++ b/client/src/GameBoard/GameBoard.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
-import Board from '../engine/Board';
-import GameBoard from './GameBoard';
+import { render, screen } from "@testing-library/react";
+import Board from "../engine/Board";
+import GameBoard from "./GameBoard";
 
 // test('renders learn react link', () => {
 //   let gameBoard = new Board(5, 5, 5)

--- a/client/src/GameBoard/GameBoard.tsx
+++ b/client/src/GameBoard/GameBoard.tsx
@@ -1,6 +1,6 @@
 import "./GameBoard.css";
 import Board, { CellIndex } from "../engine/Board";
-import Cell from "../engine/Cell"
+import Cell from "../engine/Cell";
 import GameCell from "../GameCell/GameCell";
 
 type GameBoardProps = {
@@ -8,24 +8,34 @@ type GameBoardProps = {
   onCellClick: (e: React.MouseEvent<HTMLDivElement>, cellIndex: CellIndex) => void;
 };
 
-
 function GameBoard({ gameBoard, onCellClick }: GameBoardProps) {
-  return <div className="GameBoard" id="board">
-    {gameBoard.board.map((row: Cell[], rowNumber: number) => (
-      <div className="Row" key={rowNumber}>
-        {row.map((cell: Cell, columnNumber: number) => (
-          <div className="Cell" key={columnNumber} 
-            onClick={(e: React.MouseEvent<HTMLDivElement>) => onCellClick(e, {row: rowNumber, column: columnNumber})}
-            onContextMenu={(e: React.MouseEvent<HTMLDivElement>) => onCellClick(e, {row: rowNumber, column: columnNumber})}
-          >
-            {<GameCell 
-            cellState={gameBoard.getCellState({row: rowNumber, column: columnNumber})}
-            numNeighborMines={gameBoard.getCellNumNeighborMines({row: rowNumber, column: columnNumber})}/>}
-          </div>
-        ))}
-      </div>
-    ))}
-  </div>
+  return (
+    <div className="GameBoard" id="board">
+      {gameBoard.board.map((row: Cell[], rowNumber: number) => (
+        <div className="Row" key={rowNumber}>
+          {row.map((cell: Cell, columnNumber: number) => (
+            <div
+              className="Cell"
+              key={columnNumber}
+              onClick={(e: React.MouseEvent<HTMLDivElement>) =>
+                onCellClick(e, { row: rowNumber, column: columnNumber })
+              }
+              onContextMenu={(e: React.MouseEvent<HTMLDivElement>) =>
+                onCellClick(e, { row: rowNumber, column: columnNumber })
+              }
+            >
+              {
+                <GameCell
+                  cellState={gameBoard.getCellState({ row: rowNumber, column: columnNumber })}
+                  numNeighborMines={gameBoard.getCellNumNeighborMines({ row: rowNumber, column: columnNumber })}
+                />
+              }
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export default GameBoard;

--- a/client/src/GameCell/GameCell.tsx
+++ b/client/src/GameCell/GameCell.tsx
@@ -1,45 +1,43 @@
 import "./GameCell.css";
-import {CellState, unclickedStates} from "../engine/Cell"
+import { CellState, unclickedStates } from "../engine/Cell";
 
 type GameCellProps = {
   cellState: CellState;
   numNeighborMines: number;
 };
 
-function GameCell({cellState, numNeighborMines}: GameCellProps) {
+function GameCell({ cellState, numNeighborMines }: GameCellProps) {
   const getContent = (): string => {
     if (cellState === CellState.Clicked) {
-      if (numNeighborMines > 0){
-        return String(numNeighborMines)
+      if (numNeighborMines > 0) {
+        return String(numNeighborMines);
       }
     }
     if (cellState === CellState.ClickedMine) {
-      return "💣"
+      return "💣";
     }
     if (cellState === CellState.Flagged || cellState === CellState.FlaggedMine) {
-      return "🚩"
+      return "🚩";
     }
     if (cellState === CellState.Questioned || cellState === CellState.QuestionedMine) {
-      return "❓"
+      return "❓";
     }
-    return ""
-  }
+    return "";
+  };
 
   const getClass = (): string => {
-    if (unclickedStates.includes(cellState)){
-      return "unclicked"
+    if (unclickedStates.includes(cellState)) {
+      return "unclicked";
     } else if (cellState === CellState.Clicked) {
-      return "clicked"
+      return "clicked";
     } else if (cellState === CellState.ClickedMine) {
-      return "clicked-mine"
+      return "clicked-mine";
     }
 
-    return ""
-  }
+    return "";
+  };
 
-  return <div className={`GameCell ${getClass()}`}>
-    {getContent()}
-  </div>
+  return <div className={`GameCell ${getClass()}`}>{getContent()}</div>;
 }
 
 export default GameCell;

--- a/client/src/engine/Cell.ts
+++ b/client/src/engine/Cell.ts
@@ -25,6 +25,7 @@ export const unclickedStates = [
   CellState.Questioned,
   CellState.QuestionedMine,
 ];
+export const flaggedStates = [CellState.Flagged, CellState.FlaggedMine];
 export const unclickedNonMineStates = [CellState.Unclicked, CellState.Flagged, CellState.Questioned];
 export const clickedStates = [CellState.Clicked, CellState.ClickedMine];
 


### PR DESCRIPTION
If the number of flagged neighbors is equal to the number of adjacent mines then left or right clicking an already clicked cell will attempt to clear its neighbors.

Closes #9 